### PR TITLE
Fix GIF generation on MacOS; upgrade Xabe.FFmpeg

### DIFF
--- a/src/GoMoPho/GoMoPho.csproj
+++ b/src/GoMoPho/GoMoPho.csproj
@@ -5,12 +5,13 @@
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+  <PropertyGroup Condition="'$(Platform)'=='AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xabe.FFmpeg" Version="3.4.0" />
+    <PackageReference Include="Xabe.FFmpeg" Version="5.0.2" />
+    <PackageReference Include="Xabe.FFmpeg.Downloader" Version="5.0.2" />
   </ItemGroup>
 
 </Project>

--- a/src/GoMoPhoConsole/GoMoPhoCoreConsole.csproj
+++ b/src/GoMoPhoConsole/GoMoPhoCoreConsole.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
-    <PackageReference Include="Xabe.FFmpeg" Version="3.4.0" />
+    <PackageReference Include="Xabe.FFmpeg" Version="5.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GoMoPhoFrameworkConsole/GoMoPhoFrameworkConsole.csproj
+++ b/src/GoMoPhoFrameworkConsole/GoMoPhoFrameworkConsole.csproj
@@ -49,8 +49,8 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Xabe.FFmpeg, Version=3.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xabe.FFmpeg.3.4.0\lib\netstandard2.0\Xabe.FFmpeg.dll</HintPath>
+    <Reference Include="Xabe.FFmpeg, Version=5.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xabe.FFmpeg.5.0.2\lib\netstandard2.0\Xabe.FFmpeg.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Also improves some console messages that were less clear.

GIF generation is now manually pulling out the first video stream and
using only that; ffmpeg didn't want to do conversion to gif with
multiple video streams and my motion photos (from Pixel 2, Pixel 3a, and
Pixel 4a) had multiple video streams.

Upgrade Xabe.FFmpeg to the latest version (5.0.2).

And remove the restriction of `unsafe` only on `Debug` builds because
I couldn't compile a release build with that set.

------

I ran this against ~1200 photos from Pixel 2 / Pixel 3a / Pixel 4a personal libraries and didn't have any issues.

I've only had time to test this on MacOS.